### PR TITLE
Add command line arguments to select host, audio device, toggle jack audio server, and sample rate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cpal = "0.14.0"
+clap = { version = "4.0.10", features = ["derive"] }
+cpal = { version = "0.14.0", features = ["jack"] }

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -2,9 +2,13 @@ use cpal::traits::{DeviceTrait, HostTrait};
 use cpal::{Device, InputCallbackInfo, SampleFormat, StreamConfig, SupportedStreamConfig};
 use std::sync::{self, mpsc::Receiver, mpsc::Sender};
 
-pub fn start_audio_loop() -> (cpal::Stream, Receiver<i16>) {
-    let audio_device = get_audio_device();
-    let input_config = get_input_config(&audio_device);
+pub fn start_audio_loop(
+    device_name: Option<String>,
+    use_jack: bool,
+    sample_rate: u32, 
+) -> (cpal::Stream, Receiver<i16>) {
+    let audio_device = get_audio_device(device_name, use_jack);
+    let input_config = get_input_config(&audio_device, sample_rate);
     let sample_format = input_config.sample_format();
     let config = input_config.into();
 
@@ -13,21 +17,39 @@ pub fn start_audio_loop() -> (cpal::Stream, Receiver<i16>) {
     start_stream(&config, &audio_device, &sample_format)
 }
 
-fn get_audio_device() -> Device {
-    let host = cpal::default_host();
-    let mut devices = host.devices().expect("Host has no audio device");
-    devices
-        .find(|device| device.name().expect("Failed to retrieve audio device name") == "pulse")
-        .expect("No suitable audio device found")
+fn get_audio_device(device_name: Option<String>, use_jack: bool) -> Device {
+    let host = if use_jack {
+        cpal::host_from_id(cpal::available_hosts()
+            .into_iter()
+            .find(|id| *id == cpal::HostId::Jack)
+            .expect(
+                "jack host unavailable",
+            )).expect("jack host unavailable")
+    } else {
+        cpal::default_host()
+    };
+
+    for device in host.devices().unwrap() {
+        println!("Device name: {}", device.name().unwrap());
+    }
+
+    match device_name {
+        Some(device_name) => host
+            .devices()
+            .expect("Host has no audio device")
+            .find(|device| device.name().unwrap() == device_name)
+            .unwrap_or_else(|| panic!("No suitable audio device found with name {}", &device_name)),
+        None => host.default_input_device().expect("No default audio input found"),
+    }
 }
 
-fn get_input_config(audio_device: &Device) -> SupportedStreamConfig {
+fn get_input_config(audio_device: &Device, sample_rate: u32) -> SupportedStreamConfig {
     audio_device
         .supported_input_configs()
         .expect("Device has no supported input configs")
         .next()
         .expect("Device has no supported input configs")
-        .with_sample_rate(cpal::SampleRate(44100))
+        .with_sample_rate(cpal::SampleRate(sample_rate))
 }
 
 fn build_audio_stream<T: cpal::Sample>(

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -5,7 +5,7 @@ use std::sync::{self, mpsc::Receiver, mpsc::Sender};
 pub fn start_audio_loop(
     device_name: Option<String>,
     use_jack: bool,
-    sample_rate: u32, 
+    sample_rate: u32,
 ) -> (cpal::Stream, Receiver<i16>) {
     let audio_device = get_audio_device(device_name, use_jack);
     let input_config = get_input_config(&audio_device, sample_rate);
@@ -19,12 +19,13 @@ pub fn start_audio_loop(
 
 fn get_audio_device(device_name: Option<String>, use_jack: bool) -> Device {
     let host = if use_jack {
-        cpal::host_from_id(cpal::available_hosts()
-            .into_iter()
-            .find(|id| *id == cpal::HostId::Jack)
-            .expect(
-                "jack host unavailable",
-            )).expect("jack host unavailable")
+        cpal::host_from_id(
+            cpal::available_hosts()
+                .into_iter()
+                .find(|id| *id == cpal::HostId::Jack)
+                .expect("jack host unavailable"),
+        )
+        .expect("jack host unavailable")
     } else {
         cpal::default_host()
     };
@@ -39,7 +40,9 @@ fn get_audio_device(device_name: Option<String>, use_jack: bool) -> Device {
             .expect("Host has no audio device")
             .find(|device| device.name().unwrap() == device_name)
             .unwrap_or_else(|| panic!("No suitable audio device found with name {}", &device_name)),
-        None => host.default_input_device().expect("No default audio input found"),
+        None => host
+            .default_input_device()
+            .expect("No default audio input found"),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,27 @@
 mod audio;
 use audio::start_audio_loop;
+use clap::Parser;
+
+/// Haha brr
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Name of the input audio device to choose
+    #[arg(long)]
+    device_name: Option<String>,
+
+    /// Toggle if Jack should be used as the audio host
+    #[arg(long, default_value_t = false, action = clap::ArgAction::SetTrue)]
+    jack: bool,
+
+    /// Sample rate of the input stream
+    #[arg(long, default_value_t = 48000)]
+    sample_rate: u32,
+}
 
 fn main() {
-    let (_stream, rx) = start_audio_loop();
+    let args = Args::parse();
+    let (_stream, rx) = start_audio_loop(args.device_name, args.jack, args.sample_rate);
 
     loop {
         for patnais in &rx {


### PR DESCRIPTION
Add CLI args to remove hardcoded params in the code while keeping sane defaults

Output of the program: 
```
cargo run -- --help
Haha brr

Usage: turbo_audio [OPTIONS]

Options:
      --device-name <DEVICE_NAME>  Name of the input audio device to choose
      --jack                       Toggle if Jack should be used as the audio host
      --sample-rate <SAMPLE_RATE>  Sample rate of the input stream [default: 48000]
  -h, --help                       Print help information
  -V, --version                    Print version information
```