### PR TITLE
Replace CLI args by config file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,6 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.65"
 clap = { version = "4.0.10", features = ["derive"] }
+config = { version = "0.13.2", features = ["json"]}
 cpal = { version = "0.14.0", features = ["jack"] }
 pipewire = "0.5.0"

--- a/Settings.json
+++ b/Settings.json
@@ -1,0 +1,16 @@
+{
+    "jack": false,
+    "sample_rate": 48000,
+    "connections": [
+        {
+            "output_stream": "spotify",
+            "input_stream": "ALSA plug-in [turbo_audio]",
+            "port_connections": "AllInOrder"
+        },
+        {
+            "output_stream": "Firefox",
+            "input_stream": "ALSA plug-in [turbo_audio]",
+            "port_connections": "AllInOrder"
+        }
+    ]
+}

--- a/src/config_parser.rs
+++ b/src/config_parser.rs
@@ -25,10 +25,17 @@ impl TurboAudioConfig {
 pub fn parse_config(config_name: &str) -> anyhow::Result<TurboAudioConfig> {
     let mut config = TurboAudioConfig::new();
 
-    let settings = Config::builder()
+    let settings = match Config::builder()
         .add_source(config::File::with_name(config_name))
         .build()
-        .unwrap();
+    {
+        Ok(settings) => settings,
+        Err(error) => {
+            println!("{:?}", error);
+            println!("Failed to get settings file. Default values used");
+            return Ok(config);
+        }
+    };
 
     read_optional_variable(&mut config.jack, settings.get_bool("jack"))?;
     read_optional_variable(&mut config.sample_rate, settings.get_int("sample_rate"))?;

--- a/src/config_parser.rs
+++ b/src/config_parser.rs
@@ -1,0 +1,119 @@
+use config::{Config, ConfigError, ValueKind};
+
+use crate::pipewire_listener::{PortConnections, StreamConnections};
+
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct TurboAudioConfig {
+    pub device_name: Option<String>,
+    pub jack: bool,
+    pub sample_rate: i64,
+    pub stream_connections: Vec<StreamConnections>,
+}
+
+impl TurboAudioConfig {
+    fn new() -> Self {
+        Self {
+            device_name: None,
+            jack: false,
+            sample_rate: 48000,
+            stream_connections: vec![],
+        }
+    }
+}
+
+pub fn parse_config(config_name: &str) -> anyhow::Result<TurboAudioConfig> {
+    let mut config = TurboAudioConfig::new();
+
+    let settings = Config::builder()
+        .add_source(config::File::with_name(config_name))
+        .build()
+        .unwrap();
+
+    read_optional_variable(&mut config.jack, settings.get_bool("jack"))?;
+    read_optional_variable(&mut config.sample_rate, settings.get_int("sample_rate"))?;
+
+    let mut device_name = "Default Input Device".to_string();
+    if read_optional_variable(&mut device_name, settings.get_string("device_name"))? {
+        // Only set the device name if device name is in config
+        config.device_name = Some(device_name);
+    }
+
+    let connections = settings.get_array("connections")?;
+    for connection in connections {
+        let connection = connection.into_table()?;
+        let output_stream = connection
+            .get("output_stream")
+            .ok_or_else(|| anyhow::anyhow!("output_stream field missing from connection"))?
+            .clone()
+            .into_string()?;
+        let input_stream = connection
+            .get("input_stream")
+            .ok_or_else(|| anyhow::anyhow!("input_stream field missing from connection"))?
+            .clone()
+            .into_string()?;
+        let port_connections = connection
+            .get("port_connections")
+            .ok_or_else(|| anyhow::anyhow!("port_connections field missing from connection"))?;
+
+        match &port_connections.kind {
+            ValueKind::String(port_connections) => {
+                if port_connections == "AllInOrder" {
+                    config.stream_connections.push(StreamConnections {
+                        output_stream,
+                        input_stream,
+                        port_connections: PortConnections::AllInOrder,
+                    });
+                } else {
+                    anyhow::bail!("Invalid port connections: {}", port_connections);
+                }
+            }
+            ValueKind::Array(port_connections) => {
+                let mut connections_vec = Vec::new();
+                for port_connection in port_connections {
+                    let port_connection = port_connection.clone().into_table()?;
+                    let out_port = port_connection
+                        .get("out")
+                        .ok_or_else(|| anyhow::anyhow!("port_connection doesn't have an out port"))?
+                        .clone()
+                        .into_string()?;
+                    let in_port = port_connection
+                        .get("in")
+                        .ok_or_else(|| anyhow::anyhow!("port_connection doesn't have an in port"))?
+                        .clone()
+                        .into_string()?;
+                    connections_vec.push((out_port, in_port));
+                }
+                config.stream_connections.push(StreamConnections {
+                    output_stream,
+                    input_stream,
+                    port_connections: PortConnections::Only(connections_vec),
+                });
+            }
+            type_kind => {
+                anyhow::bail!("Invalid port connection type: {}", type_kind);
+            }
+        }
+    }
+
+    Ok(config)
+}
+
+fn read_optional_variable<T: Clone>(
+    variable: &mut T,
+    config_value: Result<T, ConfigError>,
+) -> Result<bool, ConfigError> {
+    match config_value {
+        Ok(config_value) => {
+            *variable = config_value;
+            return Ok(true);
+        }
+        Err(config_error) => match config_error {
+            ConfigError::NotFound(_) => {}
+            other_error => {
+                return Err(other_error);
+            }
+        },
+    };
+    Ok(false)
+}

--- a/src/config_parser.rs
+++ b/src/config_parser.rs
@@ -1,5 +1,3 @@
-use std::str::pattern::Pattern;
-
 use config::{Config, ConfigError, ValueKind};
 
 use crate::pipewire_listener::{PortConnections, StreamConnections};
@@ -12,103 +10,122 @@ pub struct TurboAudioConfig {
     pub sample_rate: i64,
     pub stream_connections: Vec<StreamConnections>,
 }
-pub struct TurboAudioConfigBuilder(Option<&str>);
+pub struct TurboAudioConfigBuilder(Option<String>);
 
 impl TurboAudioConfig {
     pub fn builder() -> TurboAudioConfigBuilder {
         TurboAudioConfigBuilder(None)
     }
+
+    pub fn default() -> Self {
+        Self {
+            device_name: None,
+            jack: false,
+            sample_rate: 48000,
+            stream_connections: Vec::new(),
+        }
+    }
 }
 
 impl TurboAudioConfigBuilder {
-
-    pub fn add_source(&mut self, config_name: &str) -> TurboAudioConfig {
-        self.0 = config_name.into();
+    pub fn add_source(mut self, config_name: &str) -> TurboAudioConfigBuilder {
+        self.0 = config_name.to_owned().into();
+        self
     }
 
     pub fn build(self) -> anyhow::Result<TurboAudioConfig> {
-        let config_name = self.0?;
+        let config_name = self
+            .0
+            .ok_or_else(|| anyhow::anyhow!("source was not added"))?;
         let settings = match Config::builder()
-        .add_source(config::File::with_name(config_name))
-        .build()
-    {
-        Ok(settings) => settings,
-        Err(error) => {
-            println!("{:?}", error);
-            println!("Failed to get settings file. Default values used");
-            return Ok(config);
-        }
-    };
-    let jack = read_optional_variable(settings.get_bool("jack"))?.unwrap_or(false);
-    let sample_rate = read_optional_variable(settings.get_int("sample_rate"))?.unwrap_or(48000);
-    let device_name = read_optional_variable(settings.get_string("device_name"))?
-        .unwrap_or("Default Input Device".to_string());
+            .add_source(config::File::with_name(&config_name))
+            .build()
+        {
+            Ok(settings) => settings,
+            Err(error) => {
+                println!("{:?}", error);
+                println!("Failed to get settings file. Default values used");
+                return Ok(TurboAudioConfig::default());
+            }
+        };
+        
 
-    let stream_connections = Vec::new();
-    for connection in settings.get_array("connections")? {
-        let connection = connection.into_table()?;
-        let output_stream = connection
-            .get("output_stream")
-            .ok_or_else(|| anyhow::anyhow!("output_stream field missing from connection"))?
-            .into_string()?;
-        let input_stream = connection
-            .get("input_stream")
-            .ok_or_else(|| anyhow::anyhow!("input_stream field missing from connection"))?
-            .into_string()?;
-        let port_connections = connection
-            .get("port_connections")
-            .ok_or_else(|| anyhow::anyhow!("port_connections field missing from connection"))?;
+        let mut stream_connections = Vec::new();
+        for connection in settings.get_array("connections")? {
+            let connection = connection.into_table()?;
+            let output_stream = connection
+                .get("output_stream")
+                .ok_or_else(|| anyhow::anyhow!("output_stream field missing from connection"))?
+                .clone()
+                .into_string()?;
+            let input_stream = connection
+                .get("input_stream")
+                .ok_or_else(|| anyhow::anyhow!("input_stream field missing from connection"))?
+                .clone()
+                .into_string()?;
+            let port_connections = connection
+                .get("port_connections")
+                .ok_or_else(|| anyhow::anyhow!("port_connections field missing from connection"))?
+                .clone();
 
-        match &port_connections.kind {
-            ValueKind::String(port_connections) => {
-                if port_connections == "AllInOrder" {
+            match port_connections.kind {
+                ValueKind::String(port_connections) => {
+                    if port_connections == "AllInOrder" {
+                        stream_connections.push(StreamConnections {
+                            output_stream,
+                            input_stream,
+                            port_connections: PortConnections::AllInOrder,
+                        });
+                    } else {
+                        anyhow::bail!("Invalid port connections: {}", port_connections);
+                    }
+                }
+                ValueKind::Array(port_connections) => {
+                    let mut connections_vec = Vec::new();
+                    for port_connection in port_connections {
+                        let port_connection = port_connection.into_table()?;
+                        let out_port = port_connection
+                            .get("out")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!("port_connection doesn't have an out port")
+                            })?
+                            .clone()
+                            .into_string()?;
+                        let in_port = port_connection
+                            .get("in")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!("port_connection doesn't have an in port")
+                            })?
+                            .clone()
+                            .into_string()?;
+
+                        connections_vec.push((out_port, in_port));
+                    }
                     stream_connections.push(StreamConnections {
                         output_stream,
                         input_stream,
-                        port_connections: PortConnections::AllInOrder,
+                        port_connections: PortConnections::Only(connections_vec),
                     });
-                } else {
-                    anyhow::bail!("Invalid port connections: {}", port_connections);
                 }
-            }
-            ValueKind::Array(port_connections) => {
-                let mut connections_vec = Vec::new();
-                for port_connection in port_connections {
-                    let port_connection = port_connection.into_table()?;
-                    let out_port = port_connection
-                        .get("out")
-                        .ok_or_else(|| anyhow::anyhow!("port_connection doesn't have an out port"))?
-                        .into_string()?;
-                    let in_port = port_connection
-                        .get("in")
-                        .ok_or_else(|| anyhow::anyhow!("port_connection doesn't have an in port"))?
-                        .into_string()?;
-                    connections_vec.push((out_port, in_port));
+                type_kind => {
+                    anyhow::bail!("Invalid port connection type: {}", type_kind);
                 }
-                stream_connections.push(StreamConnections {
-                    output_stream,
-                    input_stream,
-                    port_connections: PortConnections::Only(connections_vec),
-                });
-            }
-            type_kind => {
-                anyhow::bail!("Invalid port connection type: {}", type_kind);
             }
         }
-    }
 
-    Ok(TurboAudioConfig {
-        device_name: device_name.into(),
-        jack,
-        sample_rate,
-        stream_connections,
-    })
+        let jack = read_optional_variable(settings.get_bool("jack"))?.unwrap_or(false);
+        let sample_rate = read_optional_variable(settings.get_int("sample_rate"))?.unwrap_or(48000);
+        let device_name = read_optional_variable(settings.get_string("device_name"))?
+            .unwrap_or_else(|| "Default Input Device".to_string());
+
+        Ok(TurboAudioConfig {
+            device_name: device_name.into(),
+            jack,
+            sample_rate,
+            stream_connections,
+        })
     }
 }
-
-
-
-
 
 fn read_optional_variable<T: Clone>(
     config_value: Result<T, ConfigError>,
@@ -119,7 +136,5 @@ fn read_optional_variable<T: Clone>(
             ConfigError::NotFound(_) => Ok(None),
             other_error => Err(other_error),
         },
-    };
-
-    unreachable!();
+    }
 }

--- a/src/config_parser.rs
+++ b/src/config_parser.rs
@@ -12,7 +12,7 @@ pub struct TurboAudioConfig {
 }
 
 impl TurboAudioConfig {
-    pub fn new(config_file_name: &str) -> anyhow::Result<TurboAudioConfig>  {
+    pub fn new(config_file_name: &str) -> anyhow::Result<TurboAudioConfig> {
         let settings = match Config::builder()
             .add_source(config::File::with_name(config_file_name))
             .build()
@@ -24,7 +24,6 @@ impl TurboAudioConfig {
                 return Ok(TurboAudioConfig::default());
             }
         };
-        
 
         let mut stream_connections = Vec::new();
         for connection in settings.get_array("connections")? {

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ fn main() -> Result<()> {
         stream_connections,
     } = TurboAudioConfig::new(&settings_file)?;
 
-    let (_stream, _rx) = start_audio_loop(device_name, jack, sample_rate.try_into().unwrap());
+    let (_stream, _rx) = start_audio_loop(device_name, jack, sample_rate.try_into().unwrap())?;
     start_pipewire_listener(stream_connections);
     run_loop();
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ mod pipewire_listener;
 use anyhow::Result;
 use audio::start_audio_loop;
 use clap::Parser;
-use config_parser::{parse_config, TurboAudioConfig};
+use config_parser::{TurboAudioConfig};
 use pipewire_listener::start_pipewire_listener;
 
 #[derive(Parser, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ mod pipewire_listener;
 use anyhow::Result;
 use audio::start_audio_loop;
 use clap::Parser;
-use config_parser::{TurboAudioConfig};
+use config_parser::TurboAudioConfig;
 use pipewire_listener::start_pipewire_listener;
 
 #[derive(Parser, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,9 +31,7 @@ fn main() -> Result<()> {
         jack,
         sample_rate,
         stream_connections,
-    } = TurboAudioConfig::builder()
-        .add_source(&settings_file)
-        .build()?;
+    } = TurboAudioConfig::new(&settings_file)?;
 
     let (_stream, _rx) = start_audio_loop(device_name, jack, sample_rate.try_into().unwrap());
     start_pipewire_listener(stream_connections);


### PR DESCRIPTION
Since it is apparent that we will have settings to pass in to Turbo Audio, I figured it was a good idea to replace CLI args by a config file.
This config file also now supports setting up Pipewire options!
It is still unclear to me if this config file should be in the gitignore, but I figured I would keep it in the repo for now. (I connected turbo audio to spotify and firefox)

Also, this crate supports watching a file (reloading when the file changes), so we could do live updates to the config if we wanted to support it!