### PR TITLE
Add basic relation between components

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ config = { version = "0.13.2", features = ["json"]}
 cpal = { version = "0.14.0", features = ["jack"] }
 pipewire = "0.5.0"
 retry = "2.0.0"
+rand = "0.8"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,25 @@
 mod audio;
 mod config_parser;
 mod pipewire_listener;
+mod resources;
+use resources::{
+    color::Color,
+    effect::{update_moody, update_raindrop, Effect, Moody},
+    ledstrip::LedStrip,
+    settings::{MoodySettings, Settings},
+};
+use std::collections::HashMap;
+
 use anyhow::Result;
 use audio::start_audio_loop;
 use clap::Parser;
 use config_parser::TurboAudioConfig;
 use pipewire_listener::PipewireController;
+
+use crate::resources::{
+    effect::{RaindropState, Raindrops},
+    settings::RaindropSettings,
+};
 
 #[derive(Parser, Debug)]
 #[command(author, version, long_about = None)]
@@ -13,6 +27,89 @@ struct Args {
     /// Settings file
     #[arg(long, default_value_t = String::from("Settings"))]
     settings_file: String,
+}
+
+fn test_and_run_loop() {
+    let mut settings: HashMap<i32, Settings> = HashMap::default();
+    let mut effects: HashMap<i32, Effect> = HashMap::default();
+    let mut ledstrips = vec![];
+
+    let moody_settings = MoodySettings {
+        color: Color { r: 255, g: 0, b: 0 },
+    };
+    let raindrop_settings = RaindropSettings { rain_speed: 1 };
+    settings.insert(0, Settings::Moody(moody_settings));
+    settings.insert(1, Settings::Raindrop(raindrop_settings));
+
+    let moody = Moody {
+        id: 10,
+        settings_id: 0,
+    };
+    let raindrop = Raindrops {
+        id: 20,
+        settings_id: 1,
+        state: RaindropState { riples: vec![] },
+    };
+    effects.insert(10, Effect::Moody(moody));
+    effects.insert(20, Effect::Raindrop(raindrop));
+
+    let mut ls1 = LedStrip::new();
+    ls1.set_led_count(10);
+    ls1.add_effect(20, 10);
+    ledstrips.push(ls1);
+
+    for _ in 0..10 {
+        println!("{:?}", ledstrips.get(0).unwrap().colors);
+        tick(&mut ledstrips, &mut effects, &mut settings);
+    }
+    println!("{:?}", ledstrips);
+    
+    tick(&mut ledstrips, &mut effects, &mut settings);
+    println!("{:?}", ledstrips);
+    
+    settings.get_mut(&0).unwrap().mut_moody().color = Color {r: 255, g:255, b:255};
+    tick(&mut ledstrips, &mut effects, &mut settings);
+    println!("{:?}", ledstrips);
+    
+    ledstrips.get_mut(0).unwrap().set_led_count(3);
+    tick(&mut ledstrips, &mut effects, &mut settings);
+    println!("{:?}", ledstrips);
+    
+    ledstrips.get_mut(0).unwrap().set_led_count(10);
+    tick(&mut ledstrips, &mut effects, &mut settings);
+    println!("{:?}", ledstrips);
+}
+
+fn tick(
+    ledstrips: &mut Vec<LedStrip>,
+    effects: &mut HashMap<i32, Effect>,
+    settings: &mut HashMap<i32, Settings>,
+) {
+    for strip in ledstrips {
+        for (effect_id, interval) in &strip.effects {
+            let leds = strip
+                .colors
+                .get_mut(interval.0..=interval.1)
+                .expect("Ledstrip interval out of bounds");
+            match effects
+                .get_mut(effect_id)
+                .expect("Effect id was not found.")
+            {
+                Effect::Moody(moody) => {
+                    let settings = settings
+                        .get_mut(&moody.settings_id)
+                        .expect("Setting id was not found.");
+                    update_moody(leds, settings.moody());
+                }
+                Effect::Raindrop(raindrop) => {
+                    let settings = settings
+                        .get_mut(&raindrop.settings_id)
+                        .expect("Setting id was not found.");
+                    update_raindrop(leds, settings.raindrop(), &mut raindrop.state);
+                }
+            }
+        }
+    }
 }
 
 fn main() -> Result<()> {
@@ -27,8 +124,10 @@ fn main() -> Result<()> {
     let (_stream, _rx) = start_audio_loop(device_name, jack, sample_rate.try_into().unwrap())?;
     let pipewire_controller = PipewireController::new();
     pipewire_controller.set_stream_connections(stream_connections)?;
+    test_and_run_loop();
 
     loop {
         std::thread::sleep(std::time::Duration::from_secs(5));
     }
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,9 +4,8 @@ mod pipewire_listener;
 mod resources;
 use resources::{
     color::Color,
-    effect::{update_moody, update_raindrop, Effect, Moody},
+    effects::{moody::update_moody, raindrop::update_raindrop},
     ledstrip::LedStrip,
-    settings::{MoodySettings, Settings},
 };
 use std::collections::HashMap;
 
@@ -17,8 +16,12 @@ use config_parser::TurboAudioConfig;
 use pipewire_listener::PipewireController;
 
 use crate::resources::{
-    effect::{RaindropState, Raindrops},
-    settings::RaindropSettings,
+    effects::{
+        moody::{Moody, MoodySettings},
+        raindrop::{RaindropSettings, RaindropState, Raindrops},
+        Effect,
+    },
+    settings::Settings,
 };
 
 #[derive(Parser, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,18 +63,22 @@ fn test_and_run_loop() {
         tick(&mut ledstrips, &mut effects, &mut settings);
     }
     println!("{:?}", ledstrips);
-    
+
     tick(&mut ledstrips, &mut effects, &mut settings);
     println!("{:?}", ledstrips);
-    
-    settings.get_mut(&0).unwrap().mut_moody().color = Color {r: 255, g:255, b:255};
+
+    settings.get_mut(&0).unwrap().mut_moody().color = Color {
+        r: 255,
+        g: 255,
+        b: 255,
+    };
     tick(&mut ledstrips, &mut effects, &mut settings);
     println!("{:?}", ledstrips);
-    
+
     ledstrips.get_mut(0).unwrap().set_led_count(3);
     tick(&mut ledstrips, &mut effects, &mut settings);
     println!("{:?}", ledstrips);
-    
+
     ledstrips.get_mut(0).unwrap().set_led_count(10);
     tick(&mut ledstrips, &mut effects, &mut settings);
     println!("{:?}", ledstrips);

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ struct Args {
     settings_file: String,
 }
 
-fn test_and_run_loop() {
+fn test_base_relations() {
     let mut settings: HashMap<i32, Settings> = HashMap::default();
     let mut effects: HashMap<i32, Effect> = HashMap::default();
     let mut effect_settings: HashMap<i32, i32> = HashMap::default();
@@ -158,10 +158,6 @@ fn main() -> Result<()> {
     let (_stream, _rx) = start_audio_loop(device_name, jack, sample_rate.try_into().unwrap())?;
     let pipewire_controller = PipewireController::new();
     pipewire_controller.set_stream_connections(stream_connections)?;
-    test_and_run_loop();
-
-    loop {
-        std::thread::sleep(std::time::Duration::from_secs(5));
-    }
+    test_base_relations();
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ fn test_base_relations() {
     let mut settings: HashMap<i32, Settings> = HashMap::default();
     let mut effects: HashMap<i32, Effect> = HashMap::default();
     let mut effect_settings: HashMap<i32, i32> = HashMap::default();
-    let mut ledstrips = vec![];
+    let mut ledstrips = Vec::default();
 
     let moody_settings = MoodySettings {
         color: Color { r: 255, g: 0, b: 0 },
@@ -56,28 +56,18 @@ fn test_base_relations() {
     effects.insert(20, Effect::Raindrop(raindrop));
     effect_settings.insert(20, 1);
 
-    let mut ls1 = LedStrip::new();
+    let mut ls1 = LedStrip::default();
     ls1.set_led_count(10);
     ls1.add_effect(20, 10);
     ledstrips.push(ls1);
 
     for _ in 0..10 {
         println!("{:?}", ledstrips.get(0).unwrap().colors);
-        tick(
-            &mut ledstrips,
-            &mut effects,
-            &mut settings,
-            &effect_settings,
-        );
+        tick(&mut ledstrips, &mut effects, &settings, &effect_settings);
     }
     println!("{:?}", ledstrips);
 
-    tick(
-        &mut ledstrips,
-        &mut effects,
-        &mut settings,
-        &effect_settings,
-    );
+    tick(&mut ledstrips, &mut effects, &settings, &effect_settings);
     println!("{:?}", ledstrips);
 
     if let Settings::Moody(ref mut color) = settings.get_mut(&0).unwrap() {
@@ -87,37 +77,22 @@ fn test_base_relations() {
             b: 255,
         }
     };
-    tick(
-        &mut ledstrips,
-        &mut effects,
-        &mut settings,
-        &effect_settings,
-    );
+    tick(&mut ledstrips, &mut effects, &settings, &effect_settings);
     println!("{:?}", ledstrips);
 
     ledstrips.get_mut(0).unwrap().set_led_count(3);
-    tick(
-        &mut ledstrips,
-        &mut effects,
-        &mut settings,
-        &effect_settings,
-    );
+    tick(&mut ledstrips, &mut effects, &settings, &effect_settings);
     println!("{:?}", ledstrips);
 
     ledstrips.get_mut(0).unwrap().set_led_count(10);
-    tick(
-        &mut ledstrips,
-        &mut effects,
-        &mut settings,
-        &effect_settings,
-    );
+    tick(&mut ledstrips, &mut effects, &settings, &effect_settings);
     println!("{:?}", ledstrips);
 }
 
 fn tick(
     ledstrips: &mut Vec<LedStrip>,
     effects: &mut HashMap<i32, Effect>,
-    settings: &mut HashMap<i32, Settings>,
+    settings: &HashMap<i32, Settings>,
     effect_settings: &HashMap<i32, i32>,
 ) {
     for strip in ledstrips {
@@ -132,7 +107,7 @@ fn tick(
             let setting_id = effect_settings
                 .get(effect_id)
                 .expect("Setting id not found");
-            let setting = settings.get_mut(setting_id);
+            let setting = settings.get(setting_id);
             match (effect, setting) {
                 (Effect::Moody(_moody), Some(Settings::Moody(settings))) => {
                     update_moody(leds, settings);

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,10 +70,12 @@ fn test_and_run_loop() {
     tick(&mut ledstrips, &mut effects, &mut settings);
     println!("{:?}", ledstrips);
 
-    settings.get_mut(&0).unwrap().mut_moody().color = Color {
-        r: 255,
-        g: 255,
-        b: 255,
+    if let Settings::Moody(ref mut color) = settings.get_mut(&0).unwrap() {
+        color.color = Color {
+            r: 255,
+            g: 255,
+            b: 255,
+        }
     };
     tick(&mut ledstrips, &mut effects, &mut settings);
     println!("{:?}", ledstrips);
@@ -98,22 +100,20 @@ fn tick(
                 .colors
                 .get_mut(interval.0..=interval.1)
                 .expect("Ledstrip interval out of bounds");
-            match effects
+            let effect = effects
                 .get_mut(effect_id)
-                .expect("Effect id was not found.")
-            {
-                Effect::Moody(moody) => {
-                    let settings = settings
-                        .get_mut(&moody.settings_id)
-                        .expect("Setting id was not found.");
-                    update_moody(leds, settings.moody());
+                .expect("Effect id was not found.");
+            let setting = settings
+                .get_mut(effect.settings_id())
+                .expect("Setting id not found");
+            match (effect, setting) {
+                (Effect::Moody(_moody), Settings::Moody(settings)) => {
+                    update_moody(leds, settings);
                 }
-                Effect::Raindrop(raindrop) => {
-                    let settings = settings
-                        .get_mut(&raindrop.settings_id)
-                        .expect("Setting id was not found.");
-                    update_raindrop(leds, settings.raindrop(), &mut raindrop.state);
+                (Effect::Raindrop(raindrop), Settings::Raindrop(settings)) => {
+                    update_raindrop(leds, settings, &mut raindrop.state);
                 }
+                _ => panic!("Effect doesn't match settings"),
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,12 +132,12 @@ fn tick(
             let setting_id = effect_settings
                 .get(effect_id)
                 .expect("Setting id not found");
-            let setting = settings.get_mut(setting_id).expect("Setting not found");
+            let setting = settings.get_mut(setting_id);
             match (effect, setting) {
-                (Effect::Moody(_moody), Settings::Moody(settings)) => {
+                (Effect::Moody(_moody), Some(Settings::Moody(settings))) => {
                     update_moody(leds, settings);
                 }
-                (Effect::Raindrop(raindrop), Settings::Raindrop(settings)) => {
+                (Effect::Raindrop(raindrop), Some(Settings::Raindrop(settings))) => {
                     update_raindrop(leds, settings, &mut raindrop.state);
                 }
                 _ => panic!("Effect doesn't match settings"),

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -1,4 +1,4 @@
 pub mod color;
-pub mod effect;
+pub mod effects;
 pub mod ledstrip;
 pub mod settings;

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -1,5 +1,4 @@
 pub mod color;
-pub mod settings;
-pub mod ledstrip;
 pub mod effect;
-
+pub mod ledstrip;
+pub mod settings;

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -1,0 +1,5 @@
+pub mod color;
+pub mod settings;
+pub mod ledstrip;
+pub mod effect;
+

--- a/src/resources/color.rs
+++ b/src/resources/color.rs
@@ -1,0 +1,18 @@
+#[derive(Clone, Copy, Debug)]
+pub struct Color {
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
+}
+
+impl Color {
+    pub fn new() -> Color {
+        Color { r: 0, g: 0, b: 0 }
+    }
+
+    pub fn add(&mut self, rhs: &Color) {
+        self.r = self.r.saturating_add(rhs.r);
+        self.g = self.g.saturating_add(rhs.g);
+        self.b = self.b.saturating_add(rhs.b);
+    }
+}

--- a/src/resources/effect.rs
+++ b/src/resources/effect.rs
@@ -1,4 +1,7 @@
-use super::{color::Color, settings::{MoodySettings, RaindropSettings}};
+use super::{
+    color::Color,
+    settings::{MoodySettings, RaindropSettings},
+};
 use rand::Rng;
 
 pub struct Moody {
@@ -14,7 +17,7 @@ pub struct Raindrops {
 #[derive(Clone, Copy)]
 pub enum RipleDirection {
     Left,
-    Right
+    Right,
 }
 pub struct RaindropState {
     pub riples: Vec<(usize, Color, RipleDirection)>,
@@ -46,7 +49,7 @@ pub fn update_raindrop(leds: &mut [Color], settings: &RaindropSettings, state: &
                     continue;
                 }
                 current_position - SHIFT
-            },
+            }
             RipleDirection::Right => {
                 if current_position + SHIFT >= color_size {
                     continue;
@@ -54,22 +57,30 @@ pub fn update_raindrop(leds: &mut [Color], settings: &RaindropSettings, state: &
                 (current_position + SHIFT) as usize
             }
         };
-        let next_color = Color { r: color.r / 2, g: color.g / 2, b: color.b / 2 };
+        let next_color = Color {
+            r: color.r / 2,
+            g: color.g / 2,
+            b: color.b / 2,
+        };
         match leds.get_mut(next_position) {
             Some(led) => {
                 led.add(&next_color);
                 next_riples.push((next_position, next_color, *direction));
-            },
-            None => {},
+            }
+            None => {}
         }
-    } 
+    }
     for _ in 0..settings.rain_speed {
         let new_position = rand::thread_rng().gen_range(0..color_size);
-        let next_color = Color { r: 255, g: 255, b:255};
+        let next_color = Color {
+            r: 255,
+            g: 255,
+            b: 255,
+        };
         *leds.get_mut(new_position).expect("Rng lib failed.") = next_color;
         next_riples.push((new_position, next_color, RipleDirection::Left));
         next_riples.push((new_position, next_color, RipleDirection::Right));
     }
-    
+
     state.riples = next_riples;
 }

--- a/src/resources/effect.rs
+++ b/src/resources/effect.rs
@@ -62,12 +62,9 @@ pub fn update_raindrop(leds: &mut [Color], settings: &RaindropSettings, state: &
             g: color.g / 2,
             b: color.b / 2,
         };
-        match leds.get_mut(next_position) {
-            Some(led) => {
-                led.add(&next_color);
-                next_riples.push((next_position, next_color, *direction));
-            }
-            None => {}
+        if let Some(led) = leds.get_mut(next_position) {
+            led.add(&next_color);
+            next_riples.push((next_position, next_color, *direction));
         }
     }
     for _ in 0..settings.rain_speed {

--- a/src/resources/effect.rs
+++ b/src/resources/effect.rs
@@ -1,0 +1,75 @@
+use super::{color::Color, settings::{MoodySettings, RaindropSettings}};
+use rand::Rng;
+
+pub struct Moody {
+    pub id: i32,
+    pub settings_id: i32,
+}
+
+pub struct Raindrops {
+    pub id: i32,
+    pub settings_id: i32,
+    pub state: RaindropState,
+}
+#[derive(Clone, Copy)]
+pub enum RipleDirection {
+    Left,
+    Right
+}
+pub struct RaindropState {
+    pub riples: Vec<(usize, Color, RipleDirection)>,
+}
+
+pub enum Effect {
+    Moody(Moody),
+    Raindrop(Raindrops),
+}
+
+pub fn update_moody(leds: &mut [Color], settings: &MoodySettings) {
+    for led in leds {
+        *led = settings.color;
+    }
+}
+
+pub fn update_raindrop(leds: &mut [Color], settings: &RaindropSettings, state: &mut RaindropState) {
+    for led in leds.iter_mut() {
+        *led = Color::new();
+    }
+
+    let color_size = leds.len();
+    let mut next_riples: Vec<(usize, Color, RipleDirection)> = vec![];
+    const SHIFT: usize = 1;
+    for (current_position, color, direction) in &state.riples {
+        let next_position = match direction {
+            RipleDirection::Left => {
+                if current_position < &SHIFT {
+                    continue;
+                }
+                current_position - SHIFT
+            },
+            RipleDirection::Right => {
+                if current_position + SHIFT >= color_size {
+                    continue;
+                }
+                (current_position + SHIFT) as usize
+            }
+        };
+        let next_color = Color { r: color.r / 2, g: color.g / 2, b: color.b / 2 };
+        match leds.get_mut(next_position) {
+            Some(led) => {
+                led.add(&next_color);
+                next_riples.push((next_position, next_color, *direction));
+            },
+            None => {},
+        }
+    } 
+    for _ in 0..settings.rain_speed {
+        let new_position = rand::thread_rng().gen_range(0..color_size);
+        let next_color = Color { r: 255, g: 255, b:255};
+        *leds.get_mut(new_position).expect("Rng lib failed.") = next_color;
+        next_riples.push((new_position, next_color, RipleDirection::Left));
+        next_riples.push((new_position, next_color, RipleDirection::Right));
+    }
+    
+    state.riples = next_riples;
+}

--- a/src/resources/effects.rs
+++ b/src/resources/effects.rs
@@ -3,7 +3,17 @@ use self::{moody::Moody, raindrop::Raindrops};
 pub mod moody;
 pub mod raindrop;
 
+
 pub enum Effect {
     Moody(Moody),
     Raindrop(Raindrops),
+}
+
+impl Effect {
+    pub fn settings_id(&self) -> &i32 {
+        match self {
+            Effect::Moody(moody) => &moody.settings_id,
+            Effect::Raindrop(raindrop) => &raindrop.settings_id,
+        }
+    }
 }

--- a/src/resources/effects.rs
+++ b/src/resources/effects.rs
@@ -1,0 +1,9 @@
+use self::{moody::Moody, raindrop::Raindrops};
+
+pub mod moody;
+pub mod raindrop;
+
+pub enum Effect {
+    Moody(Moody),
+    Raindrop(Raindrops),
+}

--- a/src/resources/effects.rs
+++ b/src/resources/effects.rs
@@ -3,7 +3,6 @@ use self::{moody::Moody, raindrop::Raindrops};
 pub mod moody;
 pub mod raindrop;
 
-
 pub enum Effect {
     Moody(Moody),
     Raindrop(Raindrops),

--- a/src/resources/effects.rs
+++ b/src/resources/effects.rs
@@ -8,12 +8,3 @@ pub enum Effect {
     Moody(Moody),
     Raindrop(Raindrops),
 }
-
-impl Effect {
-    pub fn settings_id(&self) -> &i32 {
-        match self {
-            Effect::Moody(moody) => &moody.settings_id,
-            Effect::Raindrop(raindrop) => &raindrop.settings_id,
-        }
-    }
-}

--- a/src/resources/effects/moody.rs
+++ b/src/resources/effects/moody.rs
@@ -1,0 +1,17 @@
+use crate::resources::color::Color;
+
+pub struct Moody {
+    pub id: i32,
+    pub settings_id: i32,
+}
+
+#[derive(Clone, Copy)]
+pub struct MoodySettings {
+    pub color: Color,
+}
+
+pub fn update_moody(leds: &mut [Color], settings: &MoodySettings) {
+    for led in leds {
+        *led = settings.color;
+    }
+}

--- a/src/resources/effects/moody.rs
+++ b/src/resources/effects/moody.rs
@@ -2,7 +2,6 @@ use crate::resources::color::Color;
 
 pub struct Moody {
     pub id: i32,
-    pub settings_id: i32,
 }
 
 #[derive(Clone, Copy)]

--- a/src/resources/effects/raindrop.rs
+++ b/src/resources/effects/raindrop.rs
@@ -8,9 +8,9 @@ pub struct RaindropSettings {
 
 pub struct Raindrops {
     pub id: i32,
-    pub settings_id: i32,
     pub state: RaindropState,
 }
+
 #[derive(Clone, Copy)]
 pub enum RipleDirection {
     Left,

--- a/src/resources/effects/raindrop.rs
+++ b/src/resources/effects/raindrop.rs
@@ -1,12 +1,9 @@
-use super::{
-    color::Color,
-    settings::{MoodySettings, RaindropSettings},
-};
+use crate::resources::color::Color;
 use rand::Rng;
 
-pub struct Moody {
-    pub id: i32,
-    pub settings_id: i32,
+#[derive(Clone, Copy)]
+pub struct RaindropSettings {
+    pub rain_speed: i32,
 }
 
 pub struct Raindrops {
@@ -21,17 +18,6 @@ pub enum RipleDirection {
 }
 pub struct RaindropState {
     pub riples: Vec<(usize, Color, RipleDirection)>,
-}
-
-pub enum Effect {
-    Moody(Moody),
-    Raindrop(Raindrops),
-}
-
-pub fn update_moody(leds: &mut [Color], settings: &MoodySettings) {
-    for led in leds {
-        *led = settings.color;
-    }
 }
 
 pub fn update_raindrop(leds: &mut [Color], settings: &RaindropSettings, state: &mut RaindropState) {

--- a/src/resources/ledstrip.rs
+++ b/src/resources/ledstrip.rs
@@ -16,7 +16,7 @@ impl LedStrip {
             size: 0,
             colors: vec![],
             effects: vec![],
-            used_led_count: 0
+            used_led_count: 0,
         }
     }
 
@@ -28,7 +28,8 @@ impl LedStrip {
                 to_remove.insert(*effect_id);
             }
         }
-        self.effects.retain(|(effect_id, _interval)| !to_remove.contains(effect_id));
+        self.effects
+            .retain(|(effect_id, _interval)| !to_remove.contains(effect_id));
         self.colors.resize(size, Color::new());
     }
 
@@ -37,7 +38,10 @@ impl LedStrip {
             return false;
         }
 
-        let interval = (self.used_led_count.saturating_sub(1), self.used_led_count + size - 1);
+        let interval = (
+            self.used_led_count.saturating_sub(1),
+            self.used_led_count + size - 1,
+        );
         self.effects.push((effect_id, interval));
         self.used_led_count += size;
         true

--- a/src/resources/ledstrip.rs
+++ b/src/resources/ledstrip.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use super::color::Color;
 pub type EffectInterval = (usize, usize);
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct LedStrip {
     pub size: usize,
     pub colors: Vec<Color>,
@@ -11,15 +11,6 @@ pub struct LedStrip {
 }
 
 impl LedStrip {
-    pub fn new() -> LedStrip {
-        LedStrip {
-            size: 0,
-            colors: vec![],
-            effects: vec![],
-            used_led_count: 0,
-        }
-    }
-
     pub fn set_led_count(&mut self, size: usize) {
         self.size = size;
         let mut to_remove = HashSet::new();
@@ -38,10 +29,7 @@ impl LedStrip {
             return false;
         }
 
-        let interval = (
-            self.used_led_count.saturating_sub(1),
-            self.used_led_count + size - 1,
-        );
+        let interval = (self.used_led_count, self.used_led_count + size - 1);
         self.effects.push((effect_id, interval));
         self.used_led_count += size;
         true

--- a/src/resources/ledstrip.rs
+++ b/src/resources/ledstrip.rs
@@ -1,0 +1,45 @@
+use std::collections::HashSet;
+
+use super::color::Color;
+pub type EffectInterval = (usize, usize);
+#[derive(Debug)]
+pub struct LedStrip {
+    pub size: usize,
+    pub colors: Vec<Color>,
+    pub effects: Vec<(i32, EffectInterval)>,
+    used_led_count: usize,
+}
+
+impl LedStrip {
+    pub fn new() -> LedStrip {
+        LedStrip {
+            size: 0,
+            colors: vec![],
+            effects: vec![],
+            used_led_count: 0
+        }
+    }
+
+    pub fn set_led_count(&mut self, size: usize) {
+        self.size = size;
+        let mut to_remove = HashSet::new();
+        for (effect_id, interval) in &self.effects {
+            if interval.1 >= size {
+                to_remove.insert(*effect_id);
+            }
+        }
+        self.effects.retain(|(effect_id, _interval)| !to_remove.contains(effect_id));
+        self.colors.resize(size, Color::new());
+    }
+
+    pub fn add_effect(&mut self, effect_id: i32, size: usize) -> bool {
+        if self.used_led_count + size > self.size {
+            return false;
+        }
+
+        let interval = (self.used_led_count.saturating_sub(1), self.used_led_count + size - 1);
+        self.effects.push((effect_id, interval));
+        self.used_led_count += size;
+        true
+    }
+}

--- a/src/resources/settings.rs
+++ b/src/resources/settings.rs
@@ -1,0 +1,38 @@
+use super::color::Color;
+
+#[derive(Clone, Copy)]
+pub struct MoodySettings {
+    pub color: Color,
+}
+
+#[derive(Clone, Copy)]
+pub struct RaindropSettings {
+    pub rain_speed: i32,
+}
+
+pub enum Settings {
+    Moody(MoodySettings),
+    Raindrop(RaindropSettings),
+}
+
+impl Settings {
+    pub fn moody(&self) -> &MoodySettings {
+        match self {
+            Settings::Moody(moody) => moody,
+            _ => unreachable!()
+        }
+    }
+
+    pub fn mut_moody(&mut self) -> &mut MoodySettings {
+        match self {
+            Settings::Moody(moody) => moody,
+            _ => unreachable!()
+        }
+    }
+    pub fn raindrop(&self) -> &RaindropSettings {
+        match self {
+            Settings::Raindrop(raindrop) => raindrop,
+            _ => unreachable!()
+        }
+    }
+}

--- a/src/resources/settings.rs
+++ b/src/resources/settings.rs
@@ -4,4 +4,3 @@ pub enum Settings {
     Moody(MoodySettings),
     Raindrop(RaindropSettings),
 }
-

--- a/src/resources/settings.rs
+++ b/src/resources/settings.rs
@@ -19,20 +19,20 @@ impl Settings {
     pub fn moody(&self) -> &MoodySettings {
         match self {
             Settings::Moody(moody) => moody,
-            _ => unreachable!()
+            _ => unreachable!(),
         }
     }
 
     pub fn mut_moody(&mut self) -> &mut MoodySettings {
         match self {
             Settings::Moody(moody) => moody,
-            _ => unreachable!()
+            _ => unreachable!(),
         }
     }
     pub fn raindrop(&self) -> &RaindropSettings {
         match self {
             Settings::Raindrop(raindrop) => raindrop,
-            _ => unreachable!()
+            _ => unreachable!(),
         }
     }
 }

--- a/src/resources/settings.rs
+++ b/src/resources/settings.rs
@@ -5,24 +5,3 @@ pub enum Settings {
     Raindrop(RaindropSettings),
 }
 
-impl Settings {
-    pub fn moody(&self) -> &MoodySettings {
-        match self {
-            Settings::Moody(moody) => moody,
-            _ => unreachable!(),
-        }
-    }
-
-    pub fn mut_moody(&mut self) -> &mut MoodySettings {
-        match self {
-            Settings::Moody(moody) => moody,
-            _ => unreachable!(),
-        }
-    }
-    pub fn raindrop(&self) -> &RaindropSettings {
-        match self {
-            Settings::Raindrop(raindrop) => raindrop,
-            _ => unreachable!(),
-        }
-    }
-}

--- a/src/resources/settings.rs
+++ b/src/resources/settings.rs
@@ -1,14 +1,4 @@
-use super::color::Color;
-
-#[derive(Clone, Copy)]
-pub struct MoodySettings {
-    pub color: Color,
-}
-
-#[derive(Clone, Copy)]
-pub struct RaindropSettings {
-    pub rain_speed: i32,
-}
+use super::effects::{moody::MoodySettings, raindrop::RaindropSettings};
 
 pub enum Settings {
     Moody(MoodySettings),


### PR DESCRIPTION
This base layout assumes the following:
- LedStrips own their colors
- Effects are simple functions that take a slice of colors and apply their effect according to the settings passed
    - Effects currently hold an id to their Setting, but this might change in the future for a Rc?
- Settings are unmutable from within the update_effect functions. The update_effect functions can only mutate their state (which is not shared. Ex: Raindrop)

In the future we will have to add the logic for the connections and for how we will handle Ids.

Recommended review order for files:
- color.rs
- settings.rs
- effect.rs
- ledstrip.rs
- resources.rs
- main.rs